### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run latest-tag
-        uses: EndBug/latest-tag@v1
+        uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67  # v1
         with:
           description: This tag has been auto-generated with the latest release.


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `latest-release.yaml` | `actions/checkout` | `master` | `v6.0.2` | `de0fac2e4500…` |
| `latest-release.yaml` | `EndBug/latest-tag` | `v1` | `v1` | `8fcae8848c1e…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#126